### PR TITLE
[Feat] Delegation pattern -> UserDefaults pattern data flow

### DIFF
--- a/MC3_Tamna/MC3_Tamna/ViewController/MainListViewController.swift
+++ b/MC3_Tamna/MC3_Tamna/ViewController/MainListViewController.swift
@@ -20,7 +20,6 @@ class MainListViewController: UIViewController {
     private var animalList = ["polarbear", "elephant", "dolphin", "tiger", "panda"]
     
     @objc func toQuizView(){
-        print("Go to Quiz view")
         let detailController = QuizViewController()
         navigationController?.pushViewController(detailController, animated: true)
     }

--- a/MC3_Tamna/MC3_Tamna/ViewController/QuizViewController.swift
+++ b/MC3_Tamna/MC3_Tamna/ViewController/QuizViewController.swift
@@ -9,8 +9,7 @@ import UIKit
 
 class QuizViewController: UIViewController {
     var quiz: Quiz?
-    
-    var delegate: QuizDelegate?
+
     var animal: String?
     
     override func viewDidLoad() {
@@ -185,18 +184,10 @@ extension QuizViewController: UICollectionViewDelegateFlowLayout, UICollectionVi
         return true
     }
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-            return 50
-        }
+        return 50
+    }
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-            let spacing: CGFloat = 20
-            return CGSize(width: (collectionView.bounds.width / 2 - spacing * 2), height: 70)
-        }
-    
-}
-
-
-
-
-protocol QuizDelegate {
-    func didClearQuizID(id clearQuiz: Int)
+        let spacing: CGFloat = 20
+        return CGSize(width: (collectionView.bounds.width / 2 - spacing * 2), height: 70)
+    }
 }

--- a/MC3_Tamna/MC3_Tamna/ViewController/QuizViewController.swift
+++ b/MC3_Tamna/MC3_Tamna/ViewController/QuizViewController.swift
@@ -96,7 +96,7 @@ class QuizViewController: UIViewController {
         return imageView
     }()
     
-    private let quizSubmit: UIButton = {
+    private lazy var quizSubmit: UIButton = {
         // view 최하단에 있는 제출 버튼
         let quizSubmit = UIButton()
         quizSubmit.setTitle("정답 제출하기", for: .normal)

--- a/MC3_Tamna/MC3_Tamna/ViewController/StarViewController.swift
+++ b/MC3_Tamna/MC3_Tamna/ViewController/StarViewController.swift
@@ -13,7 +13,7 @@ protocol ContentDelegate {
     func didClearContentID(id clearContent: Int)
 }
 
-class StarViewController: UIViewController, QuizDelegate {
+class StarViewController: UIViewController {
     
     var delegate: ContentDelegate?
     
@@ -159,7 +159,6 @@ extension StarViewController: UICollectionViewDelegate, UICollectionViewDataSour
         guard indexPath.row == clearIndex + 1 else { return }
         let vc = QuizViewController()
         vc.quiz = content.quizzes[indexPath.row] // 12. quiz 건네기
-        vc.delegate = self // 13. 데이터 전달받기위해 delegate 채택
         navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/MC3_Tamna/MC3_Tamna/ViewController/StarViewController.swift
+++ b/MC3_Tamna/MC3_Tamna/ViewController/StarViewController.swift
@@ -31,11 +31,7 @@ class StarViewController: UIViewController, QuizDelegate {
     private var lottieFrames: [CGFloat] = []
     
     // 6. 가장 마지막으로 clear된 quiz의 index
-    private var clearIndex = -1 {
-        didSet { // 7. clear 되었을 때 저장
-            UserDefaults.standard.set(clearIndex, forKey: animal ?? "panda")
-        }
-    }
+    private var clearIndex = -1
     
     // MARK: UIComponents
     

--- a/MC3_Tamna/MC3_Tamna/ViewController/StarViewController.swift
+++ b/MC3_Tamna/MC3_Tamna/ViewController/StarViewController.swift
@@ -30,8 +30,25 @@ class StarViewController: UIViewController {
     // 5. 받은 animal을 기반으로 해당 animal의 frame배열을 할당 (feat. getFrames())
     private var lottieFrames: [CGFloat] = []
     
+    
+    // 앞에서 왔는지, 뒤에서 왔는지
+    var isPushFromFront: Bool = true
+    
     // 6. 가장 마지막으로 clear된 quiz의 index
-    private var clearIndex = -1
+    /*
+     isPushFromFront 변수를 만든 이유
+     - MainVC -> StarVC로 왔을 경우에는 애니메이션 동작이 일어나선 안된다.
+     - QuizVC -> MainVC로 돌아올 경우에는 애니메이션 동작이 발생한다. 단, 문제가 풀렸을 경우만~! 그렇기에 oldValue != clearIndex조건 추가.
+     */
+    private var clearIndex = -1 {
+        didSet {
+            if !isPushFromFront && oldValue != clearIndex {
+                reloadUIComponents()
+            }
+            guard clearIndex + 1 == content.quizzes.count else { return }
+            delegate?.didClearContentID(id: content.id) //완료 시 delegate로 데이터 MainVC에 전달.
+        }
+    }
     
     // MARK: UIComponents
     
@@ -79,22 +96,23 @@ class StarViewController: UIViewController {
         
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: progressLabel)
         
-        configureSubviews()
+        loadUserDefaults() // clearIndex setting - clearIndex를 기반으로 형성되는 뷰가 있기에 가장 먼저 호출.
         
-        // 8. 저장된 clear 단계 load (저장된 것이 없을 땐 default 0을 줘버리니 조건 걸어야함)
-        if UserDefaults.standard.dictionaryRepresentation().keys.contains(animal ?? "") {
-            clearIndex = UserDefaults.standard.integer(forKey: animal ?? "")
-        }
+        configureSubviews() // subview setting
 
-        setLottieFrames() // 순서 중요
-        
-        progressLabel.text = "\(clearIndex+1)/\(content.quizzes.count)"
+        setLottieFrames() // lottie frames array setting
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         navigationController?.navigationBar.isHidden = false
+        
+        loadUserDefaults() // clearIndex setting
+        
+        isPushFromFront = false // if push: true -> false, if pop: false -> false
+        // false를 여기서 할당한 이유. loadUserDefaults는 필수적으로 viewWillAppear에서 구현되어야 제때 값의 변화를 감지할 수 있다.
+        // 헌데 viewDidLoad에서 false를 할당할 경우에는 그 이후 호출되는 viewWillAppear에 의해 애니메이션이 발생해버릴 수가 있다.
     }
     
     // MARK: Layout frame
@@ -114,29 +132,23 @@ class StarViewController: UIViewController {
         )
     }
     
-    // MARK: QuizDelegate Method
+    // 저장 key없으면 guard return. 있으면 값 세팅.
+    func loadUserDefaults() {
+        guard UserDefaults.standard.dictionaryRepresentation().keys.contains(animal ?? "") else { return }
+        clearIndex = UserDefaults.standard.integer(forKey: animal ?? "")
+    }
     
-    func didClearQuizID(id clearQuiz: Int) { // clear한 Quiz의 id (Int) 값이 전달될 것임
-        clearIndex = clearQuiz // 14. clear된 quiz의 id(==index)를 clearIndex에 할당
+    // clearIndex의 didSet구문 조건 참고. didSet 내부에서 호출.
+    func reloadUIComponents() {
+        progressLabel.text = "\(clearIndex+1)/\(content.quizzes.count)"
         
+        lottieView.play(toFrame: lottieFrames[clearIndex]) // from-to에서 to로 수정. current상태는 남아있을것이기 때문.
+        
+        //reload collection item...
         collectionView.reloadItems(at: [IndexPath.init(row: clearIndex, section: 0)])
         
         if clearIndex < content.quizzes.count - 1 {
             collectionView.reloadItems(at: [IndexPath.init(row: clearIndex + 1, section: 0)])
-        }
-        
-        // 15. label 갱신
-        progressLabel.text = "\(clearIndex+1)/\(content.quizzes.count)"
-        
-        // 16. lottieView 재생
-        if clearIndex == 0 {
-            lottieView.play(fromFrame: 0, toFrame: lottieFrames[clearIndex])
-        } else {
-            lottieView.play(fromFrame: lottieFrames[clearIndex-1], toFrame: lottieFrames[clearIndex])
-        }
-        
-        if clearIndex+1 == content.quizzes.count { // 모든 문제 완료 시
-            delegate?.didClearContentID(id: content.id)
         }
     }
 }
@@ -159,6 +171,7 @@ extension StarViewController: UICollectionViewDelegate, UICollectionViewDataSour
         guard indexPath.row == clearIndex + 1 else { return }
         let vc = QuizViewController()
         vc.quiz = content.quizzes[indexPath.row] // 12. quiz 건네기
+        vc.animal = animal
         navigationController?.pushViewController(vc, animated: true)
     }
 }
@@ -178,6 +191,9 @@ private extension StarViewController {
             progressLabel.widthAnchor.constraint(equalToConstant: .hund)
         ]
         NSLayoutConstraint.activate(constraints)
+        
+        progressLabel.text = "\(clearIndex+1)/\(content.quizzes.count)"
+        //text 할당을 UILabel 초기화 코드에서 하지않은 이유 -> breakPoint를 걸어보면 UILabel 초기화클로저가 viewDidLoad보다도 먼저 실행됨. 그렇기에 아직 UserDefaults에서 clearIndex를 로드해주지 못한 상황이라 "0/4"로 나타나게 되버림. 그렇기에 viewDidLoad에서 잡아줌.
     }
     
     func setLottieFrames() {
@@ -197,7 +213,7 @@ private extension StarViewController {
         default:
             break
         }
-        // 10. 나갔다 들어왔을 때 clear한 단계까지의 lottie frame 상태가 되도록 설정
+        
         if clearIndex != -1 {
             lottieView.currentFrame = lottieFrames[clearIndex]
         }

--- a/MC3_Tamna/MC3_Tamna/ViewController/StarViewController.swift
+++ b/MC3_Tamna/MC3_Tamna/ViewController/StarViewController.swift
@@ -19,22 +19,21 @@ class StarViewController: UIViewController {
     
     // MARK: Properties
     
-    // 3. MainVC로부터 전달받음
+    // MainVC로부터 전달받음
     var animal: String?
     
-    // 4. 받은 animal을 기반으로 해당 content 불러와서 할당
+    // 받은 animal을 기반으로 해당 content 불러와서 할당
     private var content: AnimalQuizzes {
         QuizDao().getQuizzessByName(animalName: animal ?? "panda")
     }
     
-    // 5. 받은 animal을 기반으로 해당 animal의 frame배열을 할당 (feat. getFrames())
+    // 받은 animal을 기반으로 해당 animal의 frame배열을 할당 (feat. getFrames())
     private var lottieFrames: [CGFloat] = []
     
     
-    // 앞에서 왔는지, 뒤에서 왔는지
+    // 앞에서 왔는지, 뒤에서 왔는지!
     var isPushFromFront: Bool = true
     
-    // 6. 가장 마지막으로 clear된 quiz의 index
     /*
      isPushFromFront 변수를 만든 이유
      - MainVC -> StarVC로 왔을 경우에는 애니메이션 동작이 일어나선 안된다.

--- a/MC3_Tamna/MC3_Tamna/ViewController/StarViewController.swift
+++ b/MC3_Tamna/MC3_Tamna/ViewController/StarViewController.swift
@@ -130,26 +130,6 @@ class StarViewController: UIViewController {
             height: .screenW + .hund
         )
     }
-    
-    // 저장 key없으면 guard return. 있으면 값 세팅.
-    func loadUserDefaults() {
-        guard UserDefaults.standard.dictionaryRepresentation().keys.contains(animal ?? "") else { return }
-        clearIndex = UserDefaults.standard.integer(forKey: animal ?? "")
-    }
-    
-    // clearIndex의 didSet구문 조건 참고. didSet 내부에서 호출.
-    func reloadUIComponents() {
-        progressLabel.text = "\(clearIndex+1)/\(content.quizzes.count)"
-        
-        lottieView.play(toFrame: lottieFrames[clearIndex]) // from-to에서 to로 수정. current상태는 남아있을것이기 때문.
-        
-        //reload collection item...
-        collectionView.reloadItems(at: [IndexPath.init(row: clearIndex, section: 0)])
-        
-        if clearIndex < content.quizzes.count - 1 {
-            collectionView.reloadItems(at: [IndexPath.init(row: clearIndex + 1, section: 0)])
-        }
-    }
 }
 
 // MARK: Delegate, DataSource
@@ -215,6 +195,26 @@ private extension StarViewController {
         
         if clearIndex != -1 {
             lottieView.currentFrame = lottieFrames[clearIndex]
+        }
+    }
+    
+    // 저장 key없으면 guard return. 있으면 값 세팅.
+    func loadUserDefaults() {
+        guard UserDefaults.standard.dictionaryRepresentation().keys.contains(animal ?? "") else { return }
+        clearIndex = UserDefaults.standard.integer(forKey: animal ?? "")
+    }
+    
+    // clearIndex의 didSet구문 조건 참고. didSet 내부에서 호출.
+    func reloadUIComponents() {
+        progressLabel.text = "\(clearIndex+1)/\(content.quizzes.count)"
+        
+        lottieView.play(toFrame: lottieFrames[clearIndex]) // from-to에서 to로 수정. current상태는 남아있을것이기 때문.
+        
+        //reload collection item...
+        collectionView.reloadItems(at: [IndexPath.init(row: clearIndex, section: 0)])
+        
+        if clearIndex < content.quizzes.count - 1 {
+            collectionView.reloadItems(at: [IndexPath.init(row: clearIndex + 1, section: 0)])
         }
     }
 }

--- a/MC3_Tamna/MC3_Tamna/ViewController/SubmitCompleteViewController.swift
+++ b/MC3_Tamna/MC3_Tamna/ViewController/SubmitCompleteViewController.swift
@@ -85,8 +85,6 @@ class SubmitCompleteViewController: UIViewController {
     
     @objc private func clearButtonTapped() {
         UserDefaults.standard.set(quiz!.id, forKey: animal ?? "panda")
-        print("버킬: \(quiz?.id)")
-        print("버킬: \(animal)")
         for controller in self.navigationController!.viewControllers as Array {
             if controller.isKind(of: StarViewController.self) {
                     self.navigationController!.popToViewController(controller, animated: true)

--- a/MC3_Tamna/MC3_Tamna/ViewController/SubmitCompleteViewController.swift
+++ b/MC3_Tamna/MC3_Tamna/ViewController/SubmitCompleteViewController.swift
@@ -70,7 +70,7 @@ class SubmitCompleteViewController: UIViewController {
         return success
     }()
     
-    private let endButton: UIButton = {
+    private lazy var endButton: UIButton = {
         // 해설을 전부 보고, 나가는 버튼
         let button = UIButton()
         button.setTitle("완료", for: .normal)

--- a/MC3_Tamna/MC3_Tamna/ViewController/SubmitCompleteViewController.swift
+++ b/MC3_Tamna/MC3_Tamna/ViewController/SubmitCompleteViewController.swift
@@ -84,7 +84,9 @@ class SubmitCompleteViewController: UIViewController {
     // FIXME: func didClearQuizID did not work
     
     @objc private func clearButtonTapped() {
-        UserDefaults.standard.set(quiz?.id, forKey: animal ?? "panda")
+        UserDefaults.standard.set(quiz!.id, forKey: animal ?? "panda")
+        print("버킬: \(quiz?.id)")
+        print("버킬: \(animal)")
         for controller in self.navigationController!.viewControllers as Array {
             if controller.isKind(of: StarViewController.self) {
                     self.navigationController!.popToViewController(controller, animated: true)

--- a/MC3_Tamna/MC3_Tamna/ViewController/SubmitCompleteViewController.swift
+++ b/MC3_Tamna/MC3_Tamna/ViewController/SubmitCompleteViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 class SubmitCompleteViewController: UIViewController {
     
     var quiz: Quiz?
-    var delegate: QuizDelegate?
     var animal: String?
     
     override func viewDidLoad() {


### PR DESCRIPTION
## issue

resolved #13 

## 내용

- Delegation pattern은 인접한 VC 간 데이터 전달에 적합하기에 UserDefaults를 이용한 간접 데이터 전달 방식으로 수정함.
- Delegation pattern은 확실한 trigger설정이 가능하지만 UserDefaults의 경우 viewWillAppear를 활용한 load방식으로 이뤄지기때문에 조건을 다룰 isPushFromFront라는 Bool 타입 변수를 생성

- 1) MainVC에서 push로 StarVC에 왔을 경우
    - a. 저장값 없을 경우 -> default로 설정된 -1이 clearIndex의 값이되며 didSet호출 없음.
    - b. 저장값 있을 경우 -> 저장된 index가 clearIndex에 할당되지만 isPushFromFront가 true인 상태라 애니메이션 발생x.

- 2) QuizVC에서 pop으로 StarVC에 왔을 경우
    - a. 값 변화 없을 경우 -> didSet에 있는 if oldValue != clearIndex {} 조건식에 걸러져서 애니메이션 발생x.
    - b. 값 변화 있을 경우 -> clearIndex의 didSet에서 감지하여 해당 애니메이션 실행o.

## 새로 알게된 insights

- didSet { } 은 새로 할당된 값이 기존 값과 동일하더라도 '할당'이라는 행위가 이뤄진다면 호출된다.
    - ex) var one = 1 일 때, one = 1 처럼 동일값을 할당해도 didSet { }은 호출된다.
- viewDidLoad -> viewWillAppear -> viewDidAppear 순으로 호출된다. 그렇기에 순서에 유의하여 서브함수들을 배치해야한다.