### PR TITLE
Fix: QuizViewController Collection Scroll, Autolayout

### DIFF
--- a/MC3_Tamna/MC3_Tamna/ViewController/QuizViewController.swift
+++ b/MC3_Tamna/MC3_Tamna/ViewController/QuizViewController.swift
@@ -92,6 +92,7 @@ class QuizViewController: UIViewController {
         let collection = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         collection.register(QuizAnswerCollectionViewCell.self, forCellWithReuseIdentifier: QuizAnswerCollectionViewCell.identifier)
         collection.translatesAutoresizingMaskIntoConstraints = false
+        collection.isScrollEnabled = false
         return collection
     }()
     
@@ -188,14 +189,14 @@ class QuizViewController: UIViewController {
         ])
         NSLayoutConstraint.activate([
             quizAnswerCollection.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
-            quizAnswerCollection.topAnchor.constraint(equalTo: quizText.bottomAnchor, constant: 30 ),
+            quizAnswerCollection.topAnchor.constraint(equalTo: quizText.bottomAnchor, constant: 30),
             quizAnswerCollection.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
-            quizAnswerCollection.heightAnchor.constraint(equalTo: scrollView.heightAnchor, multiplier: 0.3)
+            quizAnswerCollection.heightAnchor.constraint(equalTo: scrollView.heightAnchor, multiplier: 0.4)
             // auto layout
         ])
         NSLayoutConstraint.activate([
             quizSubmit.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
-            quizSubmit.topAnchor.constraint(equalTo: quizAnswerCollection.bottomAnchor),
+            quizSubmit.topAnchor.constraint(equalTo: quizAnswerCollection.bottomAnchor, constant: 10),
             quizSubmit.widthAnchor.constraint(equalTo: scrollView.widthAnchor, constant: -60),
             quizSubmit.heightAnchor.constraint(equalToConstant: 40),
             quizSubmit.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -10)


### PR DESCRIPTION
## Issue
resolved #35 
resolved #36
resolved #37

## 내용
QuizViewController가 IPhone Se에서 실행 됐을 때, 의도한대로 auto layout이 기능하지 않는 문제 해결
위와 동일한 경우에, CollectionView가 Scroll 되는 문제 해결

## ToDo
* 디자인적 수정.
* 퀴즈의 답이 너무 길어지면 글 줄임표가 나타나는 문제 해결 (어떻게 해야 할 지 정해야 할 듯!)